### PR TITLE
[TIS-1510] Melhorar referência padrão de issue na action de checagem de card do Jira

### DIFF
--- a/.github/workflows/jira-issue-required.yml
+++ b/.github/workflows/jira-issue-required.yml
@@ -1,0 +1,23 @@
+on:
+  pull_request:
+    types:
+      - opened
+
+  push:
+    branches:
+      - '**'
+      - '!main'
+
+jobs:
+  jira_issue_required:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Automations Repository
+        uses: actions/checkout@v4
+
+      - name: Check Whether PR/commit is associated to a Jira issue
+        uses: ./jira-issue-required
+        with:
+          jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+          jira_user_email: ${{ secrets.JIRA_USER_EMAIL }}
+          jira_api_token: ${{ secrets.JIRA_API_TOKEN }}

--- a/jira-issue-required/action.yml
+++ b/jira-issue-required/action.yml
@@ -3,30 +3,45 @@ author: 'José Luis da Cruz Junior'
 description: 'Action para garantir que o merge só seja permitido quando a branch do PR estiver associada a um card do Jira.'
 
 inputs:
-    jira_base_url:
-        required: true
-        description: https://<your_org>.atlassian.net
-    jira_user_email:
-        required: true
-        description: your_user@your_domain.com
-    jira_api_token:
-        required: true
-        description: Create one at https://id.atlassian.com/manage-profile/security/api-tokens
-    possible_issue_reference:
-        description: Uma string que possivelmente contém o issue no Jira. Pode ser o nome da branch, o título do PR, etc. O padrão é o nome da branch.
-        default: ${{ github.ref_name }}
+  jira_base_url:
+    required: true
+    description: https://<your_org>.atlassian.net
+  jira_user_email:
+    required: true
+    description: your_user@your_domain.com
+  jira_api_token:
+    required: true
+    description: Create one at https://id.atlassian.com/manage-profile/security/api-tokens
+  possible_issue_reference:
+    description: Uma string que possivelmente contém o issue no Jira. Pode ser o nome da branch, o título do PR, etc. O padrão é o nome da branch.
+    default: ""
 
 runs:
-    using: composite
-    steps:
-        - name: Jira Login
-          uses: atlassian/gajira-login@v3
-          env:
-              JIRA_BASE_URL: ${{ inputs.jira_base_url }}
-              JIRA_USER_EMAIL: ${{ inputs.jira_user_email }}
-              JIRA_API_TOKEN: ${{ inputs.jira_api_token }}
+  using: composite
+  steps:
 
-        - name: Find Issue Key
-          uses: atlassian/gajira-find-issue-key@v3
-          with:
-              string: ${{ inputs.possible_issue_reference }}
+    - name: Setup | Environment
+      shell: bash
+      run: echo "POSSIBLE_ISSUE_REFERENCE=${{ inputs.possible_issue_reference }}" >> "$GITHUB_ENV"
+
+    - name: Get Possible Issue Reference - Default / Push Event
+      if: env.POSSIBLE_ISSUE_REFERENCE == '' && github.event_name == 'push'
+      shell: bash
+      run: echo "POSSIBLE_ISSUE_REFERENCE=${{ github.ref_name }}" >> "$GITHUB_ENV"
+    
+    - name: Get Possible Issue Reference - Default / Pull Request Event
+      if: env.POSSIBLE_ISSUE_REFERENCE == '' && startsWith(github.event_name, 'pull_request')
+      shell: bash
+      run: echo "POSSIBLE_ISSUE_REFERENCE=${{ github.head_ref }}" >> "$GITHUB_ENV"
+
+    - name: Jira Login
+      uses: atlassian/gajira-login@v3
+      env:
+        JIRA_BASE_URL: ${{ inputs.jira_base_url }}
+        JIRA_USER_EMAIL: ${{ inputs.jira_user_email }}
+        JIRA_API_TOKEN: ${{ inputs.jira_api_token }}
+
+    - name: Find Issue Key
+      uses: atlassian/gajira-find-issue-key@v3
+      with:
+        string: ${{ env.POSSIBLE_ISSUE_REFERENCE }}


### PR DESCRIPTION
## Sobre o PR

Esse PR ajusta a action do Jira quando o parâmetro `possible_isue_reference` é deixado como padrão.

Hoje, a action promete usar o nome da branch por padrão. Contudo, o GitHub parece enviar outro valor para o `github.ref_name` quando o evento que deu trigger no workflow é `pull_request`. Nesse caso, o `ref_name` é algo como `<número_do_pr>/merge`.

Esse PR, então, testa qual tipo de evento deu trigger no workflow para garantir que sempre seja retornado o nome da branch.

## Outras mudanças

O PR também adiciona um workflow próprio do Jira que consome sua própria action, com o intuito tanto de testar este PR quanto de atender as normas da GDI.