### PR TITLE
Feat: Atualizar tags de versões em novas releases

### DIFF
--- a/.github/workflows/update-semver-tags-on-release.yml
+++ b/.github/workflows/update-semver-tags-on-release.yml
@@ -1,0 +1,30 @@
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+jobs:
+  bump-tags-semver:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Update Minor Tag
+        shell: bash
+        run: |
+          MINOR_TAG=$(echo '${{ github.event.release.tag_name }}' | grep -Po 'v\d+\.\d+')
+          git tag -f "$MINOR_TAG"
+
+      - name: Update Major Tag
+        shell: bash
+        run: |
+          MAJOR_TAG=$(echo '${{ github.event.release.tag_name }}' | grep -Po 'v\d+')
+          git tag -f "$MAJOR_TAG"
+
+      - name: Push Changes
+        shell: bash
+        run: git push -f --tags


### PR DESCRIPTION
## Sobre o PR

Este PR adiciona um workflow que visa manter as tags atualizadas seguindo [o guia de versionamento de actions do GitHub](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions#example-developer-process). A documentação ressalta:

> We recommend creating releases using semantically versioned tags – for example, **v1.1.3** – and keeping major (**v1**) and minor (**v1.1**) tags current to the latest appropriate commit. For more information, see "[About custom actions](https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-release-management-for-actions)" and "[About semantic versioning](https://docs.npmjs.com/about-semantic-versioning).