### PR TITLE
[TIS-1511] Ajustes no rotulador | Action falha quando o review decision é nulo

### DIFF
--- a/.github/workflows/pr-approved.yml
+++ b/.github/workflows/pr-approved.yml
@@ -1,0 +1,22 @@
+on:
+  pull_request_review:
+    types:
+      - submitted
+      - dismissed
+
+  pull_request:
+    types:
+      - review_requested
+
+jobs:
+  juggle_labels_on_approve:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add and Remove 'waiting QA' and 'waiting review' labels
+        uses: ./declarative-labeler
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          when_review_status: APPROVED
+          then_add_labels: waiting QA
+          then_remove_labels: waiting review
+          also_reverse: true

--- a/.github/workflows/pr-approved.yml
+++ b/.github/workflows/pr-approved.yml
@@ -12,6 +12,9 @@ jobs:
   juggle_labels_on_approve:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Automations Repository
+        uses: actions/checkout@v4
+
       - name: Add and Remove 'waiting QA' and 'waiting review' labels
         uses: ./declarative-labeler
         with:

--- a/.github/workflows/pr-created.yml
+++ b/.github/workflows/pr-created.yml
@@ -1,0 +1,19 @@
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+
+jobs:
+  add_waiting_review_label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark PR as ready by adding/removing 'waiting review' label
+        uses: ./declarative-labeler
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          when_pr_is: ready
+          then_add_labels: waiting review
+          also_reverse: true

--- a/.github/workflows/pr-created.yml
+++ b/.github/workflows/pr-created.yml
@@ -10,6 +10,9 @@ jobs:
   add_waiting_review_label:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Automations Repository
+        uses: actions/checkout@v4
+
       - name: Mark PR as ready by adding/removing 'waiting review' label
         uses: ./declarative-labeler
         with:

--- a/declarative-labeler/action.yml
+++ b/declarative-labeler/action.yml
@@ -64,8 +64,8 @@ runs:
         
         echo "review_decision=$review_decision" >> "$GITHUB_OUTPUT"
 
-    - name: When | Approved
-      if: env.PASSING == 'true' && steps.review-decision.outputs.review_decision != inputs.when_review_status
+    - name: When | Review Status
+      if: env.PASSING == 'true' && steps.review-decision.outputs.review_decision && steps.review-decision.outputs.review_decision != inputs.when_review_status
       shell: bash
       run: echo "PASSING=false" >> "$GITHUB_ENV"
     


### PR DESCRIPTION
## Sobre o PR

Um erro acontecia especificamente quando o review decision era nulo, fazendo com que a action invertesse seu comportamento.