### PR TITLE
[TIS-1511] Ajustes no Jira | Action passa dependendo do evento que a acionou mesmo quando não encontra uma issue

### DIFF
--- a/jira-issue-required/action.yml
+++ b/jira-issue-required/action.yml
@@ -42,6 +42,14 @@ runs:
         JIRA_API_TOKEN: ${{ inputs.jira_api_token }}
 
     - name: Find Issue Key
+      id: find-issue-key
       uses: atlassian/gajira-find-issue-key@v3
       with:
         string: ${{ env.POSSIBLE_ISSUE_REFERENCE }}
+    
+    - name: Fail if not found
+      if: steps.find-issue-key.outputs.issue == '' || steps.find-issue-key.outputs.issue == null
+      shell: bash
+      run: |
+        echo "Issue not found in '${{ env.POSSIBLE_ISSUE_REFERENCE }}'!"
+        exit 1


### PR DESCRIPTION
## Sobre o PR

Este PR faz com que a action do Jira falhe sempre que não encontrar uma issue key na string fornecida. Da maneira como foi implementada, a action nunca deliberadamente falhava, foi simplesmente aproveitado o fato que a action atlassian/gajira-find-issue-key#24 está com um erro e falha quando não encontra a mensagem do commit, algo que não existe no evento de `pull_request`.

Contudo, no evento de `push`, é possível que a action não encontre uma issue e, ao invés de retornar o erro usual, retorna sucesso. Este PR, então, checa se existe uma issue key após o retorno da action anterior, garantindo que a action só retornará sucesso no caso da existência de uma issue.