### PR TITLE
[CRX-1616] Desconsiderar input "from" na action jira-issue-required

### DIFF
--- a/jira-issue-required/action.yml
+++ b/jira-issue-required/action.yml
@@ -46,6 +46,7 @@ runs:
       uses: atlassian/gajira-find-issue-key@v3
       with:
         string: ${{ env.POSSIBLE_ISSUE_REFERENCE }}
+        from: 
     
     - name: Fail if not found
       if: steps.find-issue-key.outputs.issue == '' || steps.find-issue-key.outputs.issue == null


### PR DESCRIPTION
Apesar da action [jira-issue-required](https://github.com/iclinic/automations/tree/main/jira-issue-required) estar somente preparada para o input `string` da action `gajira-find-issue-key`, como não está sendo definido nada para o input `from`, é usado o padrão [commits](https://github.com/atlassian/gajira-find-issue-key/blob/master/action.yml#L13):

![image](https://github.com/iclinic/automations/assets/49565714/032b77c4-3ddd-4a18-9b82-bc4a6efcbf6d)

Com isso, pode ocorrer algum falso positivo ao validar as mensagens de commit.