### PR TITLE
[CDX-974] Add alternative Jira organization

### DIFF
--- a/.github/workflows/jira-issue-required.yml
+++ b/.github/workflows/jira-issue-required.yml
@@ -21,3 +21,6 @@ jobs:
           jira_base_url: ${{ secrets.JIRA_BASE_URL }}
           jira_user_email: ${{ secrets.JIRA_USER_EMAIL }}
           jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+          jira_alternative_base_url: ${{ secrets.JIRA_ALTERNATIVE_BASE_URL }}
+          jira_alternative_user_email: ${{ secrets.JIRA_ALTERNATIVE_USER_EMAIL }}
+          jira_alternative_api_token: ${{ secrets.JIRA_ALTERNATIVE_API_TOKEN }}

--- a/jira-issue-required/README.md
+++ b/jira-issue-required/README.md
@@ -17,7 +17,14 @@ Essa action se integra ao Jira para garantir que a branch associada ao Pull Requ
 Opcional:
 - `possible_issue_reference`: Este parâmetro pode ser usado para sobrescrever a string sob a qual a action procurará a *issue reference*. Por padrão, é o nome da branch.
 
-2. Dentro do seu repositório que usará o workflow, crie o arquivo `.github/workflows/jira-issue-required.yml` com o seguinte conteúdo
+2. Em alguns casos, um repositório tem relação com Jira em organizações diferentes, e para resolver esse problema foi criada uma configuração alternativa de Jira:
+- JIRA_ALTERNATIVE_BASE_URL: Com o valor `https://<sua org>.atlassian.net`;
+- JIRA_ALTERNATIVE_USER_EMAIL: Um email de um user que acesso ao Jira para validar se o card exista;
+- JIRA_ALTERNATIVE_API_TOKEN: Token criado para este fim deve ser criado em [API Tokens](https://id.atlassian.com/manage-profile/security/api-tokens);
+
+Essas variáveis são de preenchimento opcional.
+
+3. Dentro do seu repositório que usará o workflow, crie o arquivo `.github/workflows/jira-issue-required.yml` com o seguinte conteúdo
 ```yml
 on:
   pull_request:
@@ -39,4 +46,8 @@ jobs:
           jira_base_url: ${{ secrets.JIRA_BASE_URL }}
           jira_user_email: ${{ secrets.JIRA_USER_EMAIL }}
           jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+          # configuração opcional:
+          jira_alternative_base_url: ${{ secrets.JIRA_ALTERNATIVE_BASE_URL }}
+          jira_alternative_user_email: ${{ secrets.JIRA_ALTERNATIVE_USER_EMAIL }}
+          jira_alternative_api_token: ${{ secrets.JIRA_ALTERNATIVE_API_TOKEN }}
 ```

--- a/jira-issue-required/action.yml
+++ b/jira-issue-required/action.yml
@@ -15,6 +15,15 @@ inputs:
   possible_issue_reference:
     description: Uma string que possivelmente contém o issue no Jira. Pode ser o nome da branch, o título do PR, etc. O padrão é o nome da branch.
     default: ""
+  jira_alternative_base_url:
+    required: false
+    description: https://<your_org>.atlassian.net
+  jira_alternative_user_email:
+    required: false
+    description: your_user@your_domain.com
+  jira_alternative_api_token:
+    required: false
+    description: Create one at https://id.atlassian.com/manage-profile/security/api-tokens
 
 runs:
   using: composite
@@ -22,7 +31,9 @@ runs:
 
     - name: Setup | Environment
       shell: bash
-      run: echo "POSSIBLE_ISSUE_REFERENCE=${{ inputs.possible_issue_reference }}" >> "$GITHUB_ENV"
+      run: |
+        echo "POSSIBLE_ISSUE_REFERENCE=${{ inputs.possible_issue_reference }}" >> "$GITHUB_ENV"
+        echo "ISSUE_KEY_FOUND=0" >> "$GITHUB_ENV"
 
     - name: Get Possible Issue Reference - Default / Push Event
       if: env.POSSIBLE_ISSUE_REFERENCE == '' && github.event_name == 'push'
@@ -47,9 +58,39 @@ runs:
       with:
         string: ${{ env.POSSIBLE_ISSUE_REFERENCE }}
         from: 
-    
+
+    - name: Check if issue key exists
+      if: steps.find-issue-key.outputs.issue != ''
+      shell: bash
+      run: |
+        echo "ISSUE_KEY_FOUND=1" >> "$GITHUB_ENV"
+        echo "Issue key found!"
+
+    - name: Jira Login if not found issue key
+      if: env.ISSUE_KEY_FOUND == 0 && inputs.jira_alternative_base_url != '' && inputs.jira_alternative_user_email != '' && inputs.jira_alternative_api_token != ''
+      uses: atlassian/gajira-login@v3
+      env:
+        JIRA_BASE_URL: ${{ inputs.jira_alternative_base_url }}
+        JIRA_USER_EMAIL: ${{ inputs.jira_alternative_user_email }}
+        JIRA_API_TOKEN: ${{ inputs.jira_alternative_api_token }}
+
+    - name: Find in second repository if not found issue key
+      id: find-issue-key-second
+      if: env.ISSUE_KEY_FOUND == 0 && inputs.jira_alternative_base_url != '' && inputs.jira_alternative_user_email != '' && inputs.jira_alternative_api_token != ''
+      uses: atlassian/gajira-find-issue-key@v3
+      with:
+        string: ${{ env.POSSIBLE_ISSUE_REFERENCE }}
+        from: 
+
+    - name: Check if issue key exists in alternative Jira
+      if: env.ISSUE_KEY_FOUND == 0 && steps.find-issue-key-second.outputs.issue != ''
+      shell: bash
+      run: |
+        echo "ISSUE_KEY_FOUND=1" >> "$GITHUB_ENV"
+        echo "Issue key found in alternative Jira!"
+
     - name: Fail if not found
-      if: steps.find-issue-key.outputs.issue == '' || steps.find-issue-key.outputs.issue == null
+      if: env.ISSUE_KEY_FOUND == 0
       shell: bash
       run: |
         echo "Issue not found in '${{ env.POSSIBLE_ISSUE_REFERENCE }}'!"


### PR DESCRIPTION
Alguns repositórios estão relacionados a mais de uma organização no Jira e é necessário verificar se o card existe em todas elas. Por exemplo afya-spm e adh-b2b.

Para contornar esse problema, foi criada uma nova configuração (JIRA_ALTERNATIVE_*) para busca numa segunda organização.

https://afya-spm.atlassian.net/browse/CDX-974