### PR TITLE
fix: add branch.name on pull_request events

### DIFF
--- a/security/action.yml
+++ b/security/action.yml
@@ -56,6 +56,7 @@ runs:
         -Dsonar.scm.provider=git
         -Dsonar.sourceEncoding=utf-8
         ${{ github.event_name == 'push' && format('-Dsonar.branch.name={0}', github.ref_name) || '' }}
+        ${{ github.event_name == 'pull_request' && format('-Dsonar.branch.name={0}', github.head_ref) || '' }}
         ${{ github.event_name == 'pull_request' && format('-Dsonar.scm.revision={0}', github.event.pull_request.head.sha) || '' }}
         ${{ github.event_name == 'pull_request' && '-Dsonar.pullrequest.provider=github' || '' }}
         ${{ github.event_name == 'pull_request' && format('-Dsonar.pullrequest.github.repository={0}', github.repository) || '' }}


### PR DESCRIPTION
O sonar dá problemas quando a branch não existe