### PR TITLE
[TBM-465] fix: head_ref replaced by github.event.pull_request.head.ref

### DIFF
--- a/jira-issue-required/action.yml
+++ b/jira-issue-required/action.yml
@@ -74,15 +74,15 @@ runs:
 
         echo "DEFAULT_HOTFIX_PREFIX [$DEFAULT_HOTFIX_PREFIX]"
         echo "DEFAULT_REVERT_PREFIX [$DEFAULT_REVERT_PREFIX]"
-        echo "Branch name ${{ github.head_ref }}"
+        echo "Branch name ${{ github.ref_name }}"
 
-        if [[ "${{ github.head_ref }}" == "${{ env.DEFAULT_HOTFIX_PREFIX }}"* ]]; then
+        if [[ "${{ github.ref_name }}" == "${{ env.DEFAULT_HOTFIX_PREFIX }}"* ]]; then
           echo "PREFIX_TO_IGNORE_FOUND=1" >> "$GITHUB_ENV"
           echo "Hotfix branch detected, skipping Jira issue status check."
           exit 0
         fi
 
-        if [[ "${{ github.head_ref }}" == "${{ env.DEFAULT_REVERT_PREFIX }}"* ]]; then
+        if [[ "${{ github.ref_name }}" == "${{ env.DEFAULT_REVERT_PREFIX }}"* ]]; then
           echo "PREFIX_TO_IGNORE_FOUND=1" >> "$GITHUB_ENV"
           echo "Revert branch detected, skipping Jira issue status check."
           exit 0

--- a/jira-issue-required/action.yml
+++ b/jira-issue-required/action.yml
@@ -74,15 +74,15 @@ runs:
 
         echo "DEFAULT_HOTFIX_PREFIX [$DEFAULT_HOTFIX_PREFIX]"
         echo "DEFAULT_REVERT_PREFIX [$DEFAULT_REVERT_PREFIX]"
-        echo "Branch name ${{ github.ref_name }}"
+        echo "Branch name ${{ github.event.pull_request.head.ref }}"
 
-        if [[ "${{ github.ref_name }}" == "${{ env.DEFAULT_HOTFIX_PREFIX }}"* ]]; then
+        if [[ "${{ github.event.pull_request.head.ref }}" == "${{ env.DEFAULT_HOTFIX_PREFIX }}"* ]]; then
           echo "PREFIX_TO_IGNORE_FOUND=1" >> "$GITHUB_ENV"
           echo "Hotfix branch detected, skipping Jira issue status check."
           exit 0
         fi
 
-        if [[ "${{ github.ref_name }}" == "${{ env.DEFAULT_REVERT_PREFIX }}"* ]]; then
+        if [[ "${{ github.event.pull_request.head.ref }}" == "${{ env.DEFAULT_REVERT_PREFIX }}"* ]]; then
           echo "PREFIX_TO_IGNORE_FOUND=1" >> "$GITHUB_ENV"
           echo "Revert branch detected, skipping Jira issue status check."
           exit 0


### PR DESCRIPTION
# Ticket
[Correção para pegar a branch name a partir do PR (github.ref_name)](https://afya-spm.atlassian.net/browse/TBM-465)

# Description
Esse PR troca a forma de obtenção da branch do PR, pois em alguns cenários, estava vindo vazia quando não era um evento de open no PR