### PR TITLE
[TBM-608] feature: merge workflow automation for all repositories

### DIFF
--- a/.github/workflows/merge-workflow.yml
+++ b/.github/workflows/merge-workflow.yml
@@ -1,0 +1,19 @@
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  jira_issue_required:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Automations Repository
+        uses: actions/checkout@v4
+
+      - name: Check Whether PR/commit is associated to a Jira issue
+        uses: ./move_jira_ticket_after_merge
+        with:
+          jira_base_url_merge_workflow: ${{ vars.JIRA_BASE_URL_MERGE_WORKFLOW }}
+          jira_api_merge_transition_id_subtask_type: ${{ vars.JIRA_API_MERGE_TRANSITION_ID_SUBTASK_TYPE }}
+          jira_api_merge_transition_id_standard_type: ${{ vars.JIRA_API_MERGE_TRANSITION_ID_STANDARD_TYPE }}
+          jira_api_merge_useremail: ${{ vars.JIRA_API_MERGE_USEREMAIL }}
+          jira_api_merge_token: ${{ secrets.JIRA_API_MERGE_TOKEN }}

--- a/move_jira_ticket_after_merge/README.md
+++ b/move_jira_ticket_after_merge/README.md
@@ -1,0 +1,36 @@
+# MOVE JIRA TICKET AFTER MERGE
+
+Essa action se integra ao Jira para garantir que o card não seja associado a múltiplos PRs, desta forma tudo que entrar em produção deverá passar pela esteira completa. Quando o PR for mergeado, o card será automaticamente movido para a coluna seguinte, impedindo demais PR (que fazem uso do jira_issue_required@v2) de fazer o merge.
+
+
+## Configuração
+1. Veja se as settings abaixo que estão no nível de organização foram herdadas para seu repositório, caso contrário, inclua seu repositório aqui nos `Repository access` de cada uma delas em https://github.com/organizations/iclinic/settings/secrets/actions/<SECRET_NAME>
+- `JIRA_BASE_URL_MERGE_WORKFLOW`: Com o valor `https://<sua org>.atlassian.net`;
+- `JIRA_API_MERGE_USEREMAIL`: Um email de um user que acesso ao Jira para mover o card;
+- `JIRA_API_MERGE_TOKEN`: Token criado para este fim deve ser criado em [API Tokens](https://id.atlassian.com/manage-profile/security/api-tokens), e o valor que deve ser colocado aqui é o `base64(email:api_token)`
+- `JIRA_API_MERGE_TRANSITION_ID_SUBTASK_TYPE`: ID da transição no jira para tipos de subtasks (int). Ex: 341
+- `JIRA_API_MERGE_TRANSITION_ID_STANDARD_TYPE`: ID da transição no jira para tipos standard (int). Ex: 371
+- **Atenção**: Todas as settings acima ficam em variáveis ***exceto*** o token codificado como exemplo e ficar em secrets
+
+
+3. Dentro do seu repositório que usará o workflow, crie o arquivo `.github/workflows/merge-workflow.yml` com o seguinte conteúdo
+```yml
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  jira_issue_required:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move Jira ticket after Merge
+        uses: iclinic/automations/move_jira_ticket_after_merge@v1
+        with:
+          jira_base_url_merge_workflow: ${{ vars.JIRA_BASE_URL_MERGE_WORKFLOW }}
+          jira_api_merge_transition_id_subtask_type: ${{ vars.JIRA_API_MERGE_TRANSITION_ID_SUBTASK_TYPE }}
+          jira_api_merge_transition_id_standard_type: ${{ vars.JIRA_API_MERGE_TRANSITION_ID_STANDARD_TYPE }}
+          jira_api_merge_useremail: ${{ vars.JIRA_API_MERGE_USEREMAIL }}
+          jira_api_merge_token: ${{ secrets.JIRA_API_MERGE_TOKEN }}
+
+```

--- a/move_jira_ticket_after_merge/action.yml
+++ b/move_jira_ticket_after_merge/action.yml
@@ -1,0 +1,67 @@
+name: Merge Webhook
+author: 'José Luis da Cruz Junior'
+description: 'Action para garantir card do Jira será movido para a próxima etapa após o merge.'
+
+on:
+  pull_request:
+    types: [closed]
+
+inputs:
+  jira_base_url_merge_workflow:
+    required: true
+    description: https://<your_org>.atlassian.net
+  jira_api_merge_transition_id_subtask_type:
+    required: true
+    description: Integer ID fot the transition to be executed when the issue is a subtask issuetype
+    default: 341
+  jira_api_merge_transition_id_standard_type:
+    required: true
+    description: Integer ID fot the transition to be executed when the issue is a standard issuetype
+    default: 371
+  jira_api_merge_useremail:
+    required: true
+    description: Jira User email authorized to make the transition
+  jira_api_merge_token:
+    required: true
+    description: base64(user_email:jira_api_token)
+
+jobs:
+  move_jira_ticket_after_merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Requesting Issue Transition on Jira API
+        if: github.event.pull_request.merged == true
+        run: |
+            echo "GITHUB_HEAD_REF: $GITHUB_HEAD_REF"
+            echo "github_event: ${{ github.event.pull_request.merged }}"
+            ISSUE_KEY=$(echo "$GITHUB_HEAD_REF" | grep -oE '[a-zA-Z0-9]{1,10}-[0-9]+' | head -n 1)
+            echo "ISSUE_KEY=$ISSUE_KEY" >> "$GITHUB_ENV"
+            echo "Issue Key: $ISSUE_KEY"
+
+
+            JIRA_API_ISSUE_ENDPOINT="${{ inputs.jira_base_url_merge_workflow }}/rest/api/2/issue/$ISSUE_KEY"
+            echo "Requesting issuetype at $JIRA_API_ISSUE_ENDPOINT"
+            IS_SUBTASK=$(curl --request GET --url "$JIRA_API_ISSUE_ENDPOINT" --header 'Authorization: Basic ${{inputs.jira_api_merge_token}}' | jq .fields.issuetype.subtask) >> "$GITHUB_ENV"
+            echo "IS_SUBTASK=$IS_SUBTASK" >> "$GITHUB_ENV"
+
+            if [ "$IS_SUBTASK" = "true" ]; then
+              TRANSITION_ID=${{ inputs.jira_api_merge_transition_id_subtask_type }}
+            else
+              TRANSITION_ID=${{ inputs.jira_api_merge_transition_id_standard_type }}
+            fi
+            TRANSITION_ID=$(echo "$TRANSITION_ID" | jq -r 'tonumber')
+            echo "TRANSITION_ID=$TRANSITION_ID" >> "$GITHUB_ENV"
+            echo "IS_SUBTASK : $IS_SUBTASK"
+            echo "Transition ID: $TRANSITION_ID"
+
+            echo "Requesting transition for issue $ISSUE_KEY in behalf of: ${{inputs.jira_api_merge_useremail}}"
+            REQUEST_URL="${{ inputs.jira_base_url_merge_workflow }}/rest/api/2/issue/$ISSUE_KEY/transitions"
+            echo "REQUEST_URL=$REQUEST_URL" >> "$GITHUB_ENV"
+            echo "REQUEST URL: $REQUEST_URL"
+
+            REQUEST_BODY="{\"transition\":{\"id\":$TRANSITION_ID}}"
+            echo "REQUEST_BODY=$REQUEST_BODY" >> "$GITHUB_ENV"
+            echo "REQUEST_BODY: $REQUEST_BODY"
+            TRANSITION_RESPONSE=$(curl --request POST --url "$REQUEST_URL" --header 'Authorization: Basic ${{inputs.jira_api_merge_token}}' --header 'Content-Type: application/json' --data "$REQUEST_BODY")
+            echo "TRANSITION_RESPONSE=$TRANSITION_RESPONSE" >> "$GITHUB_ENV"
+            echo "TRANSITION_RESPONSE: $TRANSITION_RESPONSE"


### PR DESCRIPTION
# Ticket
[[TBM-608] Migrar o merge workflow para o automations](https://afya-spm.atlassian.net/browse/TBM-608)

# Description
Esse card visa automatizar a movimentação do card o Jira depois que o merge for feito.
A documentação de como configurar e como utilizar estão no README.md

[TBM-608]: https://afya-spm.atlassian.net/browse/TBM-608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


O código do yaml presente nesse PR já foi testado [em um repositório de testes que temos com o GPI](https://github.com/iclinic/testes-gpi/blob/master/.github/workflows/merge-workflow.yml) e o resultado pode ser conferido [aqui](https://github.com/iclinic/testes-gpi/actions/runs/13334913283/job/37247935432).