### PR TITLE
[TBM-610] fix: Adicionar a validação de merge via parâmetro

### DIFF
--- a/move_jira_ticket_after_merge/action.yml
+++ b/move_jira_ticket_after_merge/action.yml
@@ -24,13 +24,17 @@ inputs:
   jira_api_merge_token:
     required: true
     description: base64(user_email:jira_api_token)
+  is_pr_merged:
+    required: true
+    description: 'Check if the PR was merged from github.event.pull_request.merged'
+
 
 jobs:
   move_jira_ticket_after_merge:
     runs-on: ubuntu-latest
     steps:
       - name: Requesting Issue Transition on Jira API
-        if: github.event.pull_request.merged == true
+        if: is_pr_merged == true
         run: |
             echo "GITHUB_HEAD_REF: $GITHUB_HEAD_REF"
             echo "github_event: ${{ github.event.pull_request.merged }}"


### PR DESCRIPTION
# Ticket
[TBM-610 - Adicionar a validação de merge via parâmetro](https://afya-spm.atlassian.net/browse/TBM-610)

# Description
Durante o trigger da action no repositório que faz uso do `automations/move_jira_ticket_after_merge`, o trigger do github não é repassado. Logo na action em si, foi necessário incluir mais um parâmetro para que pudesse ser validado dentro da action centralizada.
A alteração foi incluir nos inputs uma variável que receberá o conteúdo de `github.event.pull_request.merged` disponível durante o merge nos repos, porém inacessível quando o import da action é feito.
