### PR TITLE
feat(SRE-4702): configure-sonarqube-for-monorepos

### DIFF
--- a/security/action.yml
+++ b/security/action.yml
@@ -53,6 +53,10 @@ inputs:
     description: 'Project Version'
     default: ''
     required: false
+  application_name:
+    description: 'Override application name for the SonarQube project key (defaults to repository name)'
+    default: ''
+    required: false
 
 runs:
   using: composite
@@ -90,7 +94,7 @@ runs:
         ${{ github.event_name == 'push' && inputs.project_version != '' && format('-Dsonar.projectVersion={0}', github.ref_name) || '' }}
       env:
         SONAR_HOST_URL: http://sonar.afya.tools:9000/
-        APPLICATION_NAME: ${{ github.event.repository.name }}
+        APPLICATION_NAME: ${{ inputs.application_name != '' && inputs.application_name || github.event.repository.name }}
         COMPANY: ${{ github.repository_owner }}
         SONAR_TOKEN: ${{ inputs.sonar_token }}
         GIT_DEPTH: 0


### PR DESCRIPTION
Adds an optional application_name input to the security action. When provided, it overrides the SonarQube project key instead of using the repository name as default. Fully backwards-compatible: callers that don't pass this input keep the current behavior.

Motivation
Monorepos with multiple independent apps were all analyzed under the same SonarQube project key. Running parallel jobs for each app caused the last one to finish to overwrite the others' results, making it impossible to see isolated metrics per team.

Usage
- uses: iclinic/automations/security@v1
  with:
    sonar_token: ${{ secrets.SONAR_TOKEN }}
    application_name: marketplace-admin-panel  # results in adhfoundation-marketplace-admin-panel